### PR TITLE
Fix integration logger instantiation and safeguards

### DIFF
--- a/Integracao/Application/Providers/IntegrationServiceProvider.php
+++ b/Integracao/Application/Providers/IntegrationServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Integracao\Application\Providers;
 use Illuminate\Support\ServiceProvider;
 use App\Integracao\Application\Services\IntegrationProcessingService;
 use App\Integracao\Application\Services\IntegrationCacheService;
-use App\Integracao\Application\Services\XMLIntegrationLoggerService;
 use App\Integracao\Infrastructure\Repositories\IntegrationRepository;
 
 class IntegrationServiceProvider extends ServiceProvider
@@ -15,8 +14,7 @@ class IntegrationServiceProvider extends ServiceProvider
         
         $this->app->singleton(IntegrationProcessingService::class, function ($app) {
             return new IntegrationProcessingService(
-                $app->make(IntegrationRepository::class),
-                $app->make(XMLIntegrationLoggerService::class)
+                $app->make(IntegrationRepository::class)
             );
         });
 
@@ -26,10 +24,6 @@ class IntegrationServiceProvider extends ServiceProvider
 
         $this->app->singleton(IntegrationRepository::class, function ($app) {
             return new IntegrationRepository();
-        });
-
-        $this->app->singleton(XMLIntegrationLoggerService::class, function ($app) {
-            return new XMLIntegrationLoggerService();
         });
     }
 

--- a/Integracao/Application/Services/IntegrationProcessingService.php
+++ b/Integracao/Application/Services/IntegrationProcessingService.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use App\Integracao\Domain\Entities\Integracao;
-use App\Integracao\Infrastructure\Parsers\XMLIntegrationsFactory;
 use App\Integracao\Application\Services\XMLIntegrationLoggerService;
 use App\Integracao\Infrastructure\Repositories\IntegrationRepository;
 use DiDom\Document;
@@ -15,20 +14,19 @@ use Exception;
 class IntegrationProcessingService
 {
     private IntegrationRepository $repository;
-    private XMLIntegrationLoggerService $logger;
+    private ?XMLIntegrationLoggerService $logger = null;
     private array $metrics = [];
 
     public function __construct(
-        IntegrationRepository $repository,
-        XMLIntegrationLoggerService $logger
+        IntegrationRepository $repository
     ) {
         $this->repository = $repository;
-        $this->logger = $logger;
     }
 
     public function processIntegration(Integracao $integration): array
     {
         $startTime = microtime(true);
+        $this->initializeLogger($integration);
 
         try {
             $this->validateIntegration($integration);
@@ -46,7 +44,7 @@ class IntegrationProcessingService
 
             $this->logSuccess($integration, $this->metrics);
 
-            return [
+            $response = [
                 'success' => true,
                 'processed_items' => $result['processed_items'] ?? 0,
                 'total_items' => $result['total_items'] ?? 0,
@@ -58,12 +56,26 @@ class IntegrationProcessingService
             $executionTime = microtime(true) - $startTime;
             $this->logError($integration, $e, $executionTime);
 
-            return [
+            $response = [
                 'success' => false,
                 'error' => $e->getMessage(),
                 'execution_time' => $executionTime
             ];
+        } finally {
+            $this->logger = null;
         }
+
+        return $response;
+    }
+
+    private function initializeLogger(Integracao $integration): void
+    {
+        $this->logger = new XMLIntegrationLoggerService($integration);
+    }
+
+    private function getLogger(): ?XMLIntegrationLoggerService
+    {
+        return $this->logger;
     }
 
     private function validateIntegration(Integracao $integration): void
@@ -341,11 +353,19 @@ class IntegrationProcessingService
 
     private function logSuccess(Integracao $integration, array $metrics): void
     {
-        $this->logger->loggerDone(
-            $metrics['total_items'],
-            $metrics['processed_items'],
-            "Integration processed successfully in {$metrics['execution_time']}s"
-        );
+        $logger = $this->getLogger();
+        if ($logger) {
+            $logger->loggerDone(
+                $metrics['total_items'],
+                $metrics['processed_items'],
+                "Integration processed successfully in {$metrics['execution_time']}s"
+            );
+        } else {
+            Log::warning('Integration logger not available to log success', [
+                'integration_id' => $integration->id,
+                'user_id' => $integration->user_id,
+            ]);
+        }
 
         Log::info("Integration completed successfully", [
             'integration_id' => $integration->id,
@@ -357,7 +377,16 @@ class IntegrationProcessingService
 
     private function logError(Integracao $integration, Exception $e, float $executionTime): void
     {
-        $this->logger->loggerErrWarn($e->getMessage());
+        $logger = $this->getLogger();
+        if ($logger) {
+            $logger->loggerErrWarn($e->getMessage());
+        } else {
+            Log::warning('Integration logger not available to log error', [
+                'integration_id' => $integration->id,
+                'user_id' => $integration->user_id,
+                'error' => $e->getMessage(),
+            ]);
+        }
 
         Log::error("Integration processing failed", [
             'integration_id' => $integration->id,

--- a/Integracao/Application/Services/XMLIntegrationLoggerService.php
+++ b/Integracao/Application/Services/XMLIntegrationLoggerService.php
@@ -3,7 +3,6 @@
 namespace App\Integracao\Application\Services;
 
 use App\Integracao\Domain\Entities\Integracao;
-use App\Integracao\Infrastructure\Parsers\XMLIntegrationsFactory;
 use Illuminate\Support\Facades\Log;
 use App\Services\DiscordLogService;
 
@@ -16,9 +15,20 @@ class XMLIntegrationLoggerService
     $this->integration = $integration;
   }
 
+  private function getUserAttribute(string $attribute, $default = 'unknown')
+  {
+    $user = $this->integration->user ?? null;
+
+    if (!$user) {
+      return $default;
+    }
+
+    return $user->{$attribute} ?? $default;
+  }
+
   public function loggerErrWarn(string $problem)
   {
-    
+
     Log::warning("🔧 PROBLEMA NA INTEGRAÇÃO: {$problem}", [
       'integration_id' => $this->integration->id ?? 'unknown',
       'integration_name' => $this->integration->system ?? 'unknown',
@@ -57,11 +67,11 @@ class XMLIntegrationLoggerService
           [
             'classe' => __CLASS__,
             'método' => __FUNCTION__,
-            'nome_usuario' => $this->integration->user->name,
-            'id_usuario' => $this->integration->user->id,
-            'link_xml' => $this->integration->link,
-            'id_integracao' => $this->integration->id,
-            'status_atual' => $this->integration->status,
+            'nome_usuario' => $this->getUserAttribute('name'),
+            'id_usuario' => $this->getUserAttribute('id'),
+            'link_xml' => $this->integration->link ?? 'unknown',
+            'id_integracao' => $this->integration->id ?? 'unknown',
+            'status_atual' => $this->integration->status ?? 'unknown',
             'tipo_integracao' => $this->integration->type ?? 'não especificado',
             'ultima_atualizacao' => $this->integration->updated_at ?? 'não especificado',
             'tentativas' => $this->integration->attempts ?? 0,
@@ -80,11 +90,11 @@ class XMLIntegrationLoggerService
           [
             'classe' => __CLASS__,
             'método' => __FUNCTION__,
-            'nome_usuario' => $this->integration->user->name,
-            'id_usuario' => $this->integration->user->id,
-            'link_xml' => $this->integration->link,
-            'id_integracao' => $this->integration->id,
-            'status_atual' => $this->integration->status,
+            'nome_usuario' => $this->getUserAttribute('name'),
+            'id_usuario' => $this->getUserAttribute('id'),
+            'link_xml' => $this->integration->link ?? 'unknown',
+            'id_integracao' => $this->integration->id ?? 'unknown',
+            'status_atual' => $this->integration->status ?? 'unknown',
             'tipo_integracao' => $this->integration->type ?? 'não especificado',
           ]
         );
@@ -98,15 +108,17 @@ class XMLIntegrationLoggerService
   public function loggerDone(int $total, int $countDone, string $problems = '')
   {
     $status = $total == $countDone ? 'Completo' : 'Parcialmente';
+    $userName = $this->getUserAttribute('name');
+    $userId = $this->getUserAttribute('id');
     $toLog = [
       'status' => $status,
-      'id_integracao' => $this->integration->id,
+      'id_integracao' => $this->integration->id ?? 'unknown',
       'total_imoveis' => $total,
       'total_processados' => $countDone,
       'taxa_sucesso' => $total > 0 ? round(($countDone / $total) * 100, 2) . '%' : '0%',
-      'nome_usuario' => $this->integration->user->name,
-      'id_usuario' => $this->integration->user->id,
-      'link_xml' => $this->integration->link,
+      'nome_usuario' => $userName,
+      'id_usuario' => $userId,
+      'link_xml' => $this->integration->link ?? 'unknown',
       'data_hora' => now()->format('Y-m-d H:i:s'),
       'tipo_integracao' => $this->integration->type ?? 'não especificado',
       'status_integracao' => $this->integration->status ?? 'não especificado',


### PR DESCRIPTION
## Summary
- instantiate XMLIntegrationLoggerService within IntegrationProcessingService using the current integration instead of resolving a shared singleton
- remove the XMLIntegrationLoggerService singleton binding and make logger access null-safe when user information is missing
- guard success and error logging to avoid fatal errors when the logger cannot be created

## Testing
- php -l Integracao/Application/Providers/IntegrationServiceProvider.php
- php -l Integracao/Application/Services/IntegrationProcessingService.php
- php -l Integracao/Application/Services/XMLIntegrationLoggerService.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7ce180f8832d8664a894a33d0f3e