### PR TITLE
Handle cURL error 18 with fallback

### DIFF
--- a/tests/IntegrationProcessingServiceTest.php
+++ b/tests/IntegrationProcessingServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Integracao\Application\Services\IntegrationProcessingService;
+use App\Integracao\Domain\Entities\Integracao;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+require __DIR__ . '/Stubs/bootstrap.php';
+require __DIR__ . '/../Integracao/Application/Services/IntegrationProcessingService.php';
+
+class TestIntegrationProcessingService extends IntegrationProcessingService
+{
+    /** @var string[] */
+    public array $fallbackResponses = [];
+
+    protected function performFallbackDownload(Integracao $integration): string
+    {
+        if (empty($this->fallbackResponses)) {
+            return parent::performFallbackDownload($integration);
+        }
+
+        return array_shift($this->fallbackResponses);
+    }
+}
+
+function callFetchXml(IntegrationProcessingService $service, Integracao $integration): string
+{
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('fetchXmlContent');
+    $method->setAccessible(true);
+
+    return $method->invoke($service, $integration);
+}
+
+function assertTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function makeIntegration(int $id, string $link): Integracao
+{
+    $integration = new Integracao();
+    $integration->id = $id;
+    $integration->link = $link;
+    $integration->user = (object) ['inative' => 0];
+
+    return $integration;
+}
+
+function runFallbackScenario(string $exceptionClass, string $expectedXml, string $label): void
+{
+    Cache::reset();
+    Log::reset();
+    Http::setSequence([new $exceptionClass('cURL error 18: transfer closed')]);
+
+    $repository = new App\Integracao\Infrastructure\Repositories\IntegrationRepository();
+    $logger = new App\Integracao\Application\Services\XMLIntegrationLoggerService();
+
+    $service = new TestIntegrationProcessingService($repository, $logger);
+    $service->fallbackResponses[] = $expectedXml;
+
+    $integration = makeIntegration($exceptionClass === ConnectionException::class ? 1 : 2, 'https://example.com/feed.xml');
+
+    $result = callFetchXml($service, $integration);
+
+    assertTrue($result === $expectedXml, sprintf('%s: expected fallback XML to be returned', $label));
+
+    $cacheKey = "xml_content_{$integration->id}_" . md5($integration->link);
+    assertTrue(Cache::get($cacheKey) === $expectedXml, sprintf('%s: fallback XML was not cached', $label));
+
+    $attemptLogs = array_filter(Log::$logs, fn ($log) => $log['message'] === 'Attempting fallback fetch for XML content');
+    assertTrue(count($attemptLogs) === 1, sprintf('%s: fallback attempt was not logged', $label));
+
+    $successLogs = array_filter(Log::$logs, fn ($log) => $log['message'] === 'Fallback XML fetch succeeded');
+    assertTrue(count($successLogs) === 1, sprintf('%s: fallback success was not logged', $label));
+}
+
+runFallbackScenario(ConnectionException::class, '<xml>connection</xml>', 'ConnectionException scenario');
+runFallbackScenario(RequestException::class, '<xml>request</xml>', 'RequestException scenario');
+
+echo "All fallback scenarios passed.\n";

--- a/tests/Stubs/bootstrap.php
+++ b/tests/Stubs/bootstrap.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support\Facades {
+    class Log
+    {
+        public static array $logs = [];
+
+        public static function info(string $message, array $context = []): void
+        {
+            self::$logs[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        }
+
+        public static function warning(string $message, array $context = []): void
+        {
+            self::$logs[] = ['level' => 'warning', 'message' => $message, 'context' => $context];
+        }
+
+        public static function error(string $message, array $context = []): void
+        {
+            self::$logs[] = ['level' => 'error', 'message' => $message, 'context' => $context];
+        }
+
+        public static function reset(): void
+        {
+            self::$logs = [];
+        }
+    }
+
+    class Cache
+    {
+        public static array $store = [];
+
+        public static function get(string $key)
+        {
+            return self::$store[$key] ?? null;
+        }
+
+        public static function put(string $key, $value, $ttl): void
+        {
+            self::$store[$key] = $value;
+        }
+
+        public static function reset(): void
+        {
+            self::$store = [];
+        }
+    }
+}
+
+namespace Illuminate\Support {
+    class Str
+    {
+        public static function contains($haystack, $needles): bool
+        {
+            foreach ((array) $needles as $needle) {
+                if ($needle === '') {
+                    continue;
+                }
+
+                if (strpos((string) $haystack, (string) $needle) !== false) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+
+namespace Illuminate\Support\Facades {
+    use Tests\Stubs\Http\PendingRequest;
+
+    class Http
+    {
+        public static array $sequence = [];
+
+        public static function setSequence(array $sequence): void
+        {
+            self::$sequence = $sequence;
+        }
+
+        public static function reset(): void
+        {
+            self::$sequence = [];
+        }
+
+        public static function popResponse()
+        {
+            if (empty(self::$sequence)) {
+                throw new \RuntimeException('No HTTP responses configured.');
+            }
+
+            $next = array_shift(self::$sequence);
+
+            if ($next instanceof \Closure) {
+                return $next();
+            }
+
+            return $next;
+        }
+
+        public static function timeout(int $seconds): PendingRequest
+        {
+            return new PendingRequest($seconds);
+        }
+    }
+}
+
+namespace Tests\Stubs\Http {
+    use Illuminate\Support\Facades\Http;
+
+    class PendingRequest
+    {
+        public function __construct(private int $timeout)
+        {
+        }
+
+        public function retry(int $times, int $sleep): self
+        {
+            return $this;
+        }
+
+        public function withHeaders(array $headers): self
+        {
+            return $this;
+        }
+
+        public function withOptions(array $options): self
+        {
+            return $this;
+        }
+
+        public function get(string $url)
+        {
+            $next = Http::popResponse();
+
+            if ($next instanceof \Closure) {
+                $next = $next($url);
+            }
+
+            if ($next instanceof \Exception) {
+                throw $next;
+            }
+
+            if (is_string($next)) {
+                return new Response(true, 200, $next);
+            }
+
+            return $next;
+        }
+    }
+
+    class Response
+    {
+        public function __construct(
+            private bool $successful = true,
+            private int $status = 200,
+            private string $body = '',
+            private array $headers = []
+        ) {
+        }
+
+        public function successful(): bool
+        {
+            return $this->successful;
+        }
+
+        public function status(): int
+        {
+            return $this->status;
+        }
+
+        public function body(): string
+        {
+            return $this->body;
+        }
+
+        public function headers(): array
+        {
+            return $this->headers;
+        }
+    }
+}
+
+namespace Illuminate\Http\Client {
+    class ConnectionException extends \Exception
+    {
+    }
+
+    class RequestException extends \Exception
+    {
+    }
+}
+
+namespace App\Integracao\Application\Services {
+    class XMLIntegrationLoggerService
+    {
+        public function __construct(...$args)
+        {
+        }
+
+        public function loggerErrWarn(string $problem): void
+        {
+        }
+
+        public function loggerDone(int $total, int $countDone, string $problems = ''): void
+        {
+        }
+    }
+}
+
+namespace App\Integracao\Infrastructure\Repositories {
+    class IntegrationRepository
+    {
+    }
+}
+
+namespace App\Integracao\Domain\Entities {
+    class Integracao
+    {
+        public int $id = 0;
+        public string $link = '';
+        public $user;
+        public $system;
+
+        public function save(): void
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect "cURL error 18" on connection/request failures and trigger the XML fallback flow with logging and caching
- extract shared cache storage logic and add a fallback download helper for reuse
- add test coverage with stubbed facades to ensure the fallback runs for ConnectionException and RequestException scenarios

## Testing
- php tests/IntegrationProcessingServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7b1892c4832dae7ac76d89ca03b1